### PR TITLE
Implemented tag counters and display on page.

### DIFF
--- a/app/assets/javascripts/answer_tags.js
+++ b/app/assets/javascripts/answer_tags.js
@@ -16,7 +16,15 @@ save_tag = function(answer_id, tag_prompt_deployment_id, control){
         value: control.value.toString()
     }));
     // Update Heatmap -- Line added March 2021 Project E2100
-    tagActionOnUpdate();
+    if (document.URL.includes("view_team")){ //Only display the heatmap on the view_team page, the update table only happens when conduct tag save action on view_team page.
+        tagActionOnUpdate();
+    }
+
+    if (document.URL.includes("view_my_scores")){ //On view_my_scores page, no heatmap exists, should not update table, but a simple counter is displayed for tagging progress.
+        var total_tags = countTotalTags();
+        var tagged_tages = countTaggedTags();
+        document.getElementById("tag_stats").innerHTML = "Tag Finished: " + tagged_tages + "/" + total_tags
+    }
 }
 
 toggleLabel = function(range) {

--- a/app/assets/javascripts/view_my_scores_helper.js
+++ b/app/assets/javascripts/view_my_scores_helper.js
@@ -1,0 +1,16 @@
+function countTotalTags() { //count total number of tags on the page
+    var tagPrompts = document.getElementsByName("tag_checkboxes[]")
+    return tagPrompts.length
+}
+
+function countTaggedTags() { //count finished tags on the page
+    var TaggedTags = 0;
+    var tagPrompts = document.getElementsByName("tag_checkboxes[]")
+
+    for (index = 0; index < tagPrompts.length; ++index) {
+        if (tagPrompts[index].value != 0) {
+            TaggedTags++;
+        }
+    }
+    return TaggedTags
+}

--- a/app/views/grades/view_my_scores.html.erb
+++ b/app/views/grades/view_my_scores.html.erb
@@ -1,5 +1,16 @@
-<H1>Score for <%= @assignment.name %></H1>
+<script type="text/javascript" src="/assets/view_my_scores_helper.js"></script>
 
+<script type="text/javascript">
+    $( document ).ready(function() {
+        var total_tags = countTotalTags()   // Added March 2021 -- Set up the on page counter on first loading the page
+        var tagged_tags = countTaggedTags()
+        document.getElementById("tag_stats").innerHTML = "Tag Finished: " + tagged_tags + "/" + total_tags
+    });
+</script>
+
+
+<H1>Score for <%= @assignment.name %></H1>
+<div id = "tag_stats"></div>
 
 
 <table class="grades" >


### PR DESCRIPTION
1. Added if branch in answer_tags.js to allow certain behavior on certain pages, since save_tag can be called on different pages, but the "on click" reaction may not apply to all the pages.
2. Added a simple counter on the view_my_scores page (aka alternate view). Base on the current arrangement of this page, a huge heatmap probably is not good for the presentation, a simple counter in "finished tags/total tags" format instead is display in the top left corner to track the current progress of tagging. The counter is dynamic, means that if a user wants to do tagging on this page, the counter will update itself dynamically to reflect the current  progress. 
![little_counter](https://user-images.githubusercontent.com/38549689/110567560-b96f9900-811f-11eb-9981-cb05c2c1f39b.png)
